### PR TITLE
feat/Add limit rater and apply them to APIs

### DIFF
--- a/middlewares/apilimitrater.js
+++ b/middlewares/apilimitrater.js
@@ -1,0 +1,25 @@
+const rateLimite = require('express-rate-limit');
+
+exports.postCUDApiLimiter = rateLimite({
+  windowMs: 60 * 1000,
+  max: 5,
+  handler(req, res, next, option) {
+    res.status(option.statusCode).json({ errorMsg: '요청 많음' });
+  },
+});
+
+exports.getApiLimiter = rateLimite({
+  windowMs: 1 * 1000,
+  max: 5,
+  handler(req, res, next, option) {
+    res.status(option.statusCode).json({ errorMsg: '조회 요청 많음' });
+  },
+});
+
+exports.commentCUDApiLimiter = rateLimite({
+  windowMs: 20 * 1000,
+  max: 5,
+  handler(req, res, next, option) {
+    res.status(option.statusCode).json({ errorMsg: '요청 많음' });
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
+        "express-rate-limit": "^6.7.0",
         "helmet": "^6.0.1",
         "joi": "^17.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -2151,6 +2152,17 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
+      "engines": {
+        "node": ">= 12.9.0"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
       }
     },
     "node_modules/ext": {
@@ -5834,6 +5846,12 @@
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       }
+    },
+    "express-rate-limit": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
+      "requires": {}
     },
     "ext": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
+    "express-rate-limit": "^6.7.0",
     "helmet": "^6.0.1",
     "joi": "^17.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/repositories/posts.repository.js
+++ b/repositories/posts.repository.js
@@ -73,8 +73,15 @@ class PostRepository {
         'createdAt',
         [Sequelize.col('User.nickname'), 'nickname'],
         [Sequelize.col('User.profileImg'), 'profileImg'],
+        [
+          Sequelize.fn('COUNT', Sequelize.col('Comments.commentId')),
+          'commentsCount',
+        ],
       ],
-      include: [{ model: Users, attributes: [] }],
+      include: [
+        { model: Users, attributes: [] },
+        { model: Comments, attributes: [] },
+      ],
     });
     return post;
   };

--- a/routes/comments.route.js
+++ b/routes/comments.route.js
@@ -3,33 +3,50 @@ const CommentController = require('../controllers/comments.controller');
 const commentRouter = Router();
 const commentController = new CommentController();
 const { isLoggedIn } = require('../middlewares/auth');
+const {
+  getApiLimiter,
+  commentCUDApiLimiter,
+} = require('../middlewares/apilimitrater');
 
 commentRouter.post(
   '/posts/:postid/comments',
   isLoggedIn,
+  commentCUDApiLimiter,
   commentController.createComment,
 );
 
-commentRouter.get('/posts/:postid/comments', commentController.getComments);
+commentRouter.get(
+  '/posts/:postid/comments',
+  getApiLimiter,
+  commentController.getComments,
+);
 
 commentRouter.put(
   '/comments/:commentid',
   isLoggedIn,
+  commentCUDApiLimiter,
   commentController.updateComment,
 );
 
 commentRouter.delete(
   '/comments/:commentid',
   isLoggedIn,
+  commentCUDApiLimiter,
   commentController.deleteComment,
 );
 
 commentRouter.post(
   '/posts/:postid/comments/:commentid',
   isLoggedIn,
+  commentCUDApiLimiter,
   commentController.createReComment,
 );
 
-commentRouter.get('/comments/me', isLoggedIn, commentController.getMyComments);
+commentRouter.get(
+  '/comments/me',
+  isLoggedIn,
+  getApiLimiter,
+  commentController.getMyComments,
+);
 
 module.exports = commentRouter;

--- a/routes/posts.route.js
+++ b/routes/posts.route.js
@@ -5,23 +5,39 @@ const multerPostImage = require('../middlewares/multer.postImage');
 const postRouter = Router();
 const postController = new PostController();
 const { isLoggedIn } = require('../middlewares/auth');
+const {
+  postCUDApiLimiter,
+  getApiLimiter,
+} = require('../middlewares/apilimitrater');
 
 postRouter.post(
   '',
   isLoggedIn,
+  postCUDApiLimiter,
   multerPostImage.single('postImage'),
   postController.createPost,
 );
-postRouter.get('', postController.getLocationPosts);
-postRouter.get('/me', isLoggedIn, postController.getMyPost);
-postRouter.get('/:postid', postController.getDetailPost);
-postRouter.get('/update/:postid', isLoggedIn, postController.getPreviousPost);
+postRouter.get('', getApiLimiter, postController.getLocationPosts);
+postRouter.get('/me', isLoggedIn, getApiLimiter, postController.getMyPost);
+postRouter.get('/:postid', getApiLimiter, postController.getDetailPost);
+postRouter.get(
+  '/update/:postid',
+  isLoggedIn,
+  getApiLimiter,
+  postController.getPreviousPost,
+);
 postRouter.patch(
   '/:postid',
   isLoggedIn,
+  postCUDApiLimiter,
   multerPostImage.single('postImage'),
   postController.updatePost,
 );
-postRouter.delete('/:postid', isLoggedIn, postController.deletePost);
+postRouter.delete(
+  '/:postid',
+  isLoggedIn,
+  postCUDApiLimiter,
+  postController.deletePost,
+);
 
 module.exports = postRouter;


### PR DESCRIPTION
DOS 공격 방지를 위한 요청 제한하는 express-rate-limit 라이브러리 추가

express-rate-limit를 이용한 각 API 별 요청제한 미들웨어를 생성

각 API에 미들웨어를 적용

게시물 상세조회에서 댓글 개수가 필요하다는 요청을 받아 post.repository의 getDetailPost 코드 수정